### PR TITLE
Codex/update calendar link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@ Hugo static site for MassProv, using a custom theme in `massprov-hugo/themes/mas
 ## Structure
 - `massprov-hugo/` – Hugo project (content, layouts, static assets, config).
 - `massprov-hugo/themes/massprov/` – custom theme (templates, CSS, images).
-- Key pages: Home (`layouts/index.html`), Contact (`layouts/page/contact.html`), Calendar (`layouts/page/calendar.html`), Submit Event (`layouts/_default/submit-event.html`), About (`content/about/`), Posts (`content/posts/`).
+- Key pages: Home (`layouts/index.html`), Contact (`layouts/page/contact.html`), Calendar (`layouts/calendar/single.html`), Submit Event (`layouts/_default/submit-event.html`), About (`content/about/`), Posts (`content/posts/`).
+
+## Local development
+- Run the site locally from the Hugo project directory:
+
+```powershell
+cd massprov-hugo
+hugo server
+```
+
+- Open `http://localhost:1313/` in your browser to preview the site.
+- Stop the local server with `Ctrl+C`.
+- If Hugo is not installed yet, install Hugo first and then rerun `hugo server`.
 
 ## Design tokens
 - Palette: Navy `#1D2A39`, Teal `#2E6B73`, Terracotta `#C55A3A`, Ochre `#D29A3A`, Sand `#F1E6C5`.

--- a/massprov-hugo/themes/massprov/layouts/calendar/single.html
+++ b/massprov-hugo/themes/massprov/layouts/calendar/single.html
@@ -4,7 +4,7 @@
     <h1>{{ .Title }}</h1>
     {{ with .Params.description }}<p class="muted">{{ . }}</p>{{ end }}
     <div class="card" style="margin-top:16px;">
-      <iframe src="https://calendar.google.com/calendar/embed?src=1b684ed3e75bec4193de4c65948cfc0f4774874b25ba137b4d5d0d9ca7101a08%40group.calendar.google.com&ctz=America%2FNew_York" style="border:0; width:100%; height:520px;" frameborder="0" scrolling="no" title="MassProv Calendar"></iframe>
+      <iframe src="https://calendar.google.com/calendar/embed?src=81687222fb24e4afa47ad547fe20830fd1fa5f5769f28dc166001ee646147d8e%40group.calendar.google.com&ctz=America%2FNew_York" style="border:0; width:100%; height:520px;" frameborder="0" scrolling="no" title="MassProv Calendar"></iframe>
     </div>
   </section>
 

--- a/massprov-hugo/themes/massprov/layouts/calendar/single.html
+++ b/massprov-hugo/themes/massprov/layouts/calendar/single.html
@@ -3,6 +3,11 @@
     <p class="pill" style="margin:0;">Calendar</p>
     <h1>{{ .Title }}</h1>
     {{ with .Params.description }}<p class="muted">{{ . }}</p>{{ end }}
+    <div class="card" style="margin-top:16px; margin-bottom:16px;">
+      <p style="margin:0 0 8px;"><strong>Calendar courtesy of the Boston Improv Calendar team.</strong></p>
+      <p class="muted" style="margin:0 0 12px;">This calendar is maintained by another community organizer. We appreciate their work keeping the improv community informed.</p>
+      <a class="btn btn-secondary" href="https://www.instagram.com/bostonimprovcalendar/" target="_blank" rel="noopener noreferrer">Visit @bostonimprovcalendar on Instagram</a>
+    </div>
     <div class="card" style="margin-top:16px;">
       <iframe src="https://calendar.google.com/calendar/embed?src=81687222fb24e4afa47ad547fe20830fd1fa5f5769f28dc166001ee646147d8e%40group.calendar.google.com&ctz=America%2FNew_York" style="border:0; width:100%; height:520px;" frameborder="0" scrolling="no" title="MassProv Calendar"></iframe>
     </div>
@@ -11,7 +16,9 @@
   <section class="section" id="submit-event">
     <p class="pill" style="margin:0;">Submit an event</p>
     <h2>Share your show, jam, or workshop.</h2>
-    <p class="muted">We’ll add your submission to the MassProv Calendar. Include contact info in case we have questions.</p>
-    <a class="btn btn-primary" style="margin-top:12px;" href="{{ "submit-event/" | relURL }}">Open submission form</a>
+    {{/* <p class="muted">We'll add your submission to the MassProv Calendar. Include contact info in case we have questions.</p> */}}
+    {{/* <a class="btn btn-primary" style="margin-top:12px;" href="{{ "submit-event/" | relURL }}">Open submission form</a> */}}
+    <p class="muted">Boston Improv Calendar maintains this calendar. If you want your event considered for listing, follow their submission instructions.</p>
+    <a class="btn btn-primary" style="margin-top:12px;" href="https://linktr.ee/bostonimprovcalendar" target="_blank" rel="noopener noreferrer">View Boston Improv Calendar submission instructions</a>
   </section>
 {{ end }}


### PR DESCRIPTION
the Boston Improv Calendar attribution
the Instagram courtesy link
the updated “Submit an event” section pointing to [Linktree](https://linktr.ee/bostonimprovcalendar)
the old direct form copy preserved as template comments in [single.html](app://-/index.html?hostId=local)